### PR TITLE
Mqtt anonymous access option added

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ The Ikea uC will do all that polling stuff for us.
 
 As reported in #16, the transitions from Green to Yellow and Yellow to Red in the Ikea firmware are at around 30 and 100μg/m³.
 | Color        | Value           | Comment  |
-| ------------- |:-------------:| -----:|
+|:------------- |:-------------:|:-----|
 | Green      | 0-35 | Good + Low |
 | Amber      | 36-85 | Ok + Medium |
 | Red      | 86- | Not good + High |

--- a/README.md
+++ b/README.md
@@ -95,6 +95,11 @@ Therefore, to add Wi-Fi connectivity, we just need to also listen to the TX of t
 The Ikea uC will do all that polling stuff for us.
 
 As reported in #16, the transitions from Green to Yellow and Yellow to Red in the Ikea firmware are at around 30 and 100μg/m³.
+Info from (https://www.ikea.com/us/en/manuals/vindriktning-air-quality-sensor__AA-2289325-1_pub.pdf):
+Green: 0-35 / Good + Low
+Amber: 36-85 / OK + Medium
+Red: 86- / Not good + High
+Pulsing: Startup Mode
 
 ## ToDo
 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ As reported in #16, the transitions from Green to Yellow and Yellow to Red in th
 | Green      | 0-35 | Good + Low |
 | Amber      | 36-85 | Ok + Medium |
 | Red      | 86- | Not good + High |
-| Pulsing      | --- | Startup mode |
+| Pulsing      | --- | Startup mode for 10 seconds|
 
 Info from (https://www.ikea.com/us/en/manuals/vindriktning-air-quality-sensor__AA-2289325-1_pub.pdf):
 

--- a/README.md
+++ b/README.md
@@ -95,11 +95,14 @@ Therefore, to add Wi-Fi connectivity, we just need to also listen to the TX of t
 The Ikea uC will do all that polling stuff for us.
 
 As reported in #16, the transitions from Green to Yellow and Yellow to Red in the Ikea firmware are at around 30 and 100μg/m³.
+| Color        | Value           | Comment  |
+| ------------- |:-------------:| -----:|
+| Green      | 0-35 | Good + Low |
+| Amber      | 36-85 | Ok + Medium |
+| Red      | 86- | Not good + High |
+| Pulsing      | --- | Startup mode |
+
 Info from (https://www.ikea.com/us/en/manuals/vindriktning-air-quality-sensor__AA-2289325-1_pub.pdf):
-Green: 0-35 / Good + Low
-Amber: 36-85 / OK + Medium
-Red: 86- / Not good + High
-Pulsing: Startup Mode
 
 ## ToDo
 

--- a/src/Config.h
+++ b/src/Config.h
@@ -8,12 +8,14 @@ namespace Config {
 
     char username[24] = "";
     char password[24] = "";
+    char mqtt_anonymous[2] = "";
 
     void save() {
         DynamicJsonDocument json(512);
         json["mqtt_server"] = mqtt_server;
         json["username"] = username;
         json["password"] = password;
+        json["mqtt_anonymous"] = mqtt_anonymous;
 
         File configFile = SPIFFS.open("/config.json", "w");
         if (!configFile) {
@@ -41,6 +43,7 @@ namespace Config {
                         strcpy(mqtt_server, json["mqtt_server"]);
                         strcpy(username, json["username"]);
                         strcpy(password, json["password"]);
+                        strcpy(mqtt_anonymous, json["mqtt_anonymous"]);
                     }
                 }
             }


### PR DESCRIPTION
Hi, I found your project and loved it right from the start.
I bought two of the Ikea devices and one is already modded. But during the weekend I found a strange issue on my mqtt (First I thought it is the sketch, but it turned out differently...of course :-) ). 

Let me explain my issue: 
If I try to connect from arduino mqtt PubSubClient with a user and password I get
**xxxxxxxx: Socket error on client <unknown>, disconnecting.**
But user and pass are definitely correct (checked with mosquitto_pub)
Same issue in case I leave the config empty, I get the same error.(guess "" is not the same as anonymous ). But as soon as I connect as anonymous  it works fine. I checked my mqtt config. And other code running (not arduino ) work fine with user and pass.
Maybe I'm on the wrong track and the issue is not user/pass but client, I need to find out why my mosquitto server does not work as expected. 

So the issue is caused by my mosquitto setup, but I could solve the topic by alter your code to use anonymous .
And here goes my proposal. Again, I'm not able to solve the issue by now on my server, but as a work around  it eases some pain)

Maybe the issue #13  is related to this? Feel free to edit the PR. I changed the code like a monkey with tool, I bet even you see a benefit you will come up with a better solution.

Again thx for the project. 
(Btw. I needed to use a LLC for my Wemos D1 to start as 5V did not work - maybe I will provide a image for the readme, you already mentioned this in a line. But that is a different topic)
