### PR TITLE
Setup PlatformIO project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.pio
+.vscode/.browse.c_cpp.db*
+.vscode/c_cpp_properties.json
+.vscode/launch.json
+.vscode/ipch

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+    // See http://go.microsoft.com/fwlink/?LinkId=827846
+    // for the documentation about the extensions.json format
+    "recommendations": [
+        "platformio.platformio-ide"
+    ]
+}

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,0 +1,18 @@
+; PlatformIO Project Configuration File
+;
+;   Build options: build flags, source filter
+;   Upload options: custom upload port, speed and extra flags
+;   Library options: dependencies, extra library storages
+;   Advanced options: extra scripting
+;
+; Please visit documentation for the other options and examples
+; https://docs.platformio.org/page/projectconf.html
+
+[env:d1_mini]
+platform = espressif8266
+board = d1_mini
+framework = arduino
+lib_deps =
+     bblanchon/ArduinoJson @ ^6.18.3
+     knolleary/PubSubClient @ ^2.8
+     tzapu/WiFiManager @ ^0.16.0


### PR DESCRIPTION
This PR makes the project compatible with PlatformIO IDE. It's very similar to https://github.com/Hypfer/esp8266-vindriktning-particle-sensor/pull/21, but it is a bit cleaner and adds only files necessarily required by PlatformIO. The default configuration is set to support the most common variants of the Wemos D1 Mini board.